### PR TITLE
Add extractors for vaststelling gemeenteweg

### DIFF
--- a/lib/extractor.js
+++ b/lib/extractor.js
@@ -1,7 +1,14 @@
 import {NamedNode, triple} from 'rdflib';
 import {DCT, ELI, ELOD, LBLOD_BESLUIT, RDF, RDFS} from '../util/namespaces';
 import {Property} from './property';
-import {DECISION_TYPES, REGULATION_TYPES, retrieveCodeList, TAX_TYPES} from "../util/codelist";
+import {
+    retrieveCodeList,
+    DECISION_TYPES,
+    REGULATION_TYPES,
+    TAX_TYPES,
+    ADOPTION_TYPES,
+    MUNICIPAL_ROAD_PROCEDURE_TYPES
+} from "../util/codelist";
 
 // extractors
 import extract from './extractors/default-extractor';
@@ -11,6 +18,8 @@ import besluitIsGehoudenDoor from './extractors/besluit-is-gehouden-door';
 import decisionType from './extractors/decision-type';
 import regulationType from './extractors/regulation-type';
 import taxType from './extractors/tax-type';
+import adoptionType from './extractors/adoption-type';
+import municipalRoadProcedureType from './extractors/municipal-road-procedure-type';
 
 const EXTRACTORS = [
     ({graph, base}) => extract({graph, base, find: RDF('type'), replaceWith: DCT('type')}),
@@ -33,6 +42,8 @@ const EXTRACTORS = [
     ({graph, base, tmp}) => decisionType({graph, base, tmp}),
     ({graph, base, tmp}) => regulationType({graph, base, tmp}),
     ({graph, base, tmp}) => taxType({graph, base, tmp}),
+    ({graph, base, tmp}) => adoptionType({graph, base, tmp}),
+    ({graph, base, tmp}) => municipalRoadProcedureType({graph, base, tmp})
 ];
 
 /**
@@ -121,7 +132,9 @@ async function preload(){
         cl: {
             decisions: await retrieveCodeList(DECISION_TYPES),
             regulations: await retrieveCodeList(REGULATION_TYPES),
-            taxTypes: await retrieveCodeList(TAX_TYPES)
+            taxTypes: await retrieveCodeList(TAX_TYPES),
+            adoptionTypes: await retrieveCodeList(ADOPTION_TYPES),
+            municipalRoadProcedureTypes: await retrieveCodeList(MUNICIPAL_ROAD_PROCEDURE_TYPES)
         }
     }
 }

--- a/lib/extractors/adoption-type.js
+++ b/lib/extractors/adoption-type.js
@@ -1,0 +1,7 @@
+import {RDF, LBLOD_BESLUIT} from '../../util/namespaces';
+import {default as defaultExtract} from './default-extractor';
+
+export default function extract({graph, base, tmp}) {
+  const types = defaultExtract({graph, base, find: LBLOD_BESLUIT('AdoptionType')});
+  return types.filter(prop => tmp.cl.adoptionTypes.includes(prop.object.value));
+}

--- a/lib/extractors/municipal-road-procedure-type.js
+++ b/lib/extractors/municipal-road-procedure-type.js
@@ -1,0 +1,7 @@
+import {RDF, LBLOD_BESLUIT} from '../../util/namespaces';
+import {default as defaultExtract} from './default-extractor';
+
+export default function extract({graph, base, tmp}) {
+  const types = defaultExtract({graph, base, find: LBLOD_BESLUIT('MunicipalRoadProcedureType')});
+  return types.filter(prop => tmp.cl.municipalRoadProcedureTypes.includes(prop.object.value));
+}

--- a/util/codelist.js
+++ b/util/codelist.js
@@ -4,7 +4,8 @@ import {retrieveCodeListQuery} from "./queries";
 export const DECISION_TYPES = 'http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5';
 export const REGULATION_TYPES = 'http://lblod.data.gift/concept-schemes/c93ccd41-aee7-488f-86d3-038de890d05a';
 export const TAX_TYPES = 'http://lblod.data.gift/concept-schemes/3037c4f4-1c63-43ac-bfc4-b41d098b15a6';
-
+export const ADOPTION_TYPES = 'http://lblod.data.gift/concept-schemes/a995bb71-3c87-4385-a06b-a786f2fa0d16';
+export const MUNICIPAL_ROAD_PROCEDURE_TYPES = 'http://lblod.data.gift/concept-schemes/60d620a5-ec34-4a91-ba84-fff0813d0ccc';
 
 export async function retrieveCodeList(uri){
   try {


### PR DESCRIPTION
These extractors populate the generated form data with two more predicates : `AdoptionType` and `MunicipalRoadProcedureType`.

While testing I also made the test of overriding form data by calling manually the `/flatten` endpoint and it went really fine : no modified URIs, only the two added predicates showing. We can proceed with the migration script :)