### PR TITLE
Use cogs:Job and task:Task and integrate with job-controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,64 +13,14 @@ toezicht-flattened-form-data-generator:
 
 The volume mounted in `/share/submissions` must contain the Turtle files containing the data to fill in the forms.
 
-Configure the delta-notification service to send notifications on the `/delta` endpoint by adding the following rules in `./delta/rules.js`:
-
-```javascript
-export default [
-  {
-    match: {
-      predicate: {
-        type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status'
-      },
-      object: {
-        type: 'uri',
-        value: 'http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c'  // sent status
-      }
-    },
-    callback: {
-      url: 'http://toezicht-flattened-form-data-generator/delta',
-      method: 'POST'
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true
-    }
-  },
-  {
-    match: {
-      predicate: {
-        type: "uri",
-        value: "http://www.w3.org/ns/adms#status"
-      },
-      object: {
-        type: "uri",
-        value: "http://lblod.data.gift/automatische-melding-statuses/successful-concept"
-      }
-    },
-    callback: {
-      method: "POST",
-      url: "http://save-sent-submission/delta"
-    },
-    options: {
-      resourceFormat: "v0.0.1",
-      gracePeriod: 1000,
-      ignoreFromSelf: true
-    }
-  }
-]
-```
+Configure the delta-notifier according to the tasks as defined in the model of the [job-controller-service](https://github.com/lblod/job-controller-service).
 
 ## API
 
 ### POST /delta
 Triggers the flat-mapping of the resources related to a submission document and saves this as `melding:FormData` resource into the triple-store.
 
-The service is triggered by updates from the following resources:
-
- - a submission is submitted. I.e. resource of type `meb:Submission`of which the `adms:status` is updated to `<http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c>`
- - an automatic submission resulted in a new concept submission. I.e. resource of type `melding:AutomaticSubmissionTask` of with the `adms:status` is updated to `<http://lblod.data.gift/automatische-melding-statuses/successful-concept>`
+The service is triggered when a task for this service has been created. This is the case when a submission has the status of `<http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c>` or when the resultsContainer has the status of `http://lblod.data.gift/automatische-melding-statuses/successful-concept`. In both situations, the task from the previous service in the flow has status "success", so this is what is used to trigger this service.
 
 The `/delta` handling consists of 3 (major) steps:
 

--- a/app.js
+++ b/app.js
@@ -118,59 +118,7 @@ app.put('/submission-documents/:uuid/flatten', async function (req, res) {
   }
 });
 
-//async function processInsertions(delta) {
-//  // TODO make it more easy to add new triggers <=> creation strategies.
-//  let submissions = [];
-//
-//  // get submissions for submission URIs
-//  let inserts = delta.getInsertsFor(triple(undefined, ADMS('status'), new NamedNode(SUBMISSION_SENT_STATUS)));
-//  for (let triple of inserts) {
-//    const submission = await createSubmissionFromSubmission(triple.subject.value);
-//    if (submission)
-//      submissions.push(submission);
-//  }
-//
-//  // get submissions for submission-task URIs
-//  inserts = delta.getInsertsFor(triple(undefined, ADMS('status'), new NamedNode(SUBMISSION_TASK_SUCCESSFUL)));
-//  for (let triple of inserts) {
-//    const submission = await createSubmissionFromSubmissionTask(triple.subject.value);
-//    if (submission)
-//      submissions.push(submission);
-//  }
-//
-//  if (submissions.length) {
-//    processSubmissions(submissions); // don't await async processing
-//  }
-//  return submissions;
-//}
-
-//async function processSubmissions(submissions) {
-//  for (const submission of submissions) {
-//    try {
-//      await processSubmission(submission);
-//    } catch (e) {
-//      console.log('Something went wrong while trying to extract the form-data from the submissions');
-//      console.log(`Exception: ${e.stack}`);
-//    }
-//  }
-//}
-
 async function processSubmission(submission) {
   const form = new FormData({ submission });
   await form.flatten();
 }
-
-//async function processDeletions(delta) {
-//  let deletions = delta.getInsertsFor(triple(undefined, ADMS('status'), new NamedNode(SUBMISSION_DELETED_STATUS)));
-//
-//  for (let triple of deletions) {
-//    try {
-//      await deleteFormDataFromSubmission(triple.subject.value);
-//    } catch (e) {
-//      console.log('Something went wrong while trying to delete the form data');
-//      console.log(`Exception: ${e.stack}`);
-//    }
-//  }
-//
-//  return deletions;
-//}

--- a/app.js
+++ b/app.js
@@ -2,17 +2,15 @@ import { NamedNode, triple } from 'rdflib';
 import bodyParser from 'body-parser';
 import { app } from 'mu';
 import {
-  createSubmissionFromSubmission,
   createSubmissionFromSubmissionResource,
   createSubmissionFromSubmissionTask,
-  deleteFormDataFromSubmission,
-  SUBMISSION_SENT_STATUS,
-  SUBMISSION_DELETED_STATUS,
-  SUBMISSION_TASK_SUCCESSFUL,
 } from './lib/submission';
 import { FormData } from './lib/form-data';
-import { ADMS } from './util/namespaces';
+import { TASK } from './util/namespaces';
 import { Delta } from './lib/delta';
+import * as env from './env.js';
+import { updateTaskStatus } from './lib/submission-task.js';
+import { saveError } from './lib/submission-error.js';
 
 app.use(
   bodyParser.json({
@@ -27,20 +25,50 @@ app.get('/', function (req, res) {
 });
 
 app.post('/delta', async function (req, res) {
-  const delta = new Delta(req.body);
+  //We can already send a 200 back. The delta-notifier does not care about the result, as long as the request is closed.
+  res.status(200).send();
 
-  if (!delta.inserts.length) {
-    console.log('Delta does not contain any insertions. Nothing should happen.');
-    return res.status(204).send();
-  }
+  try {
+    const delta = new Delta(req.body);
+    debugger;
 
-  const submissions = await processInsertions(delta);
-  const deletions = await processDeletions(delta);
+    //Collect the triples about that form-data-generate operation of a task
+    const relevantTaskTriples = delta.getInsertsFor(
+      triple(
+        undefined,
+        TASK('operation'),
+        new NamedNode(env.FORM_DATA_GENERATE_OPERATION)
+      )
+    );
 
-  if (!submissions && !deletions) {
-    return res.status(204).send();
-  } else {
-    return res.status(200).send();
+    for (const triple of relevantTaskTriples) {
+      const taskUri = triple.subject.value;
+      try {
+        //TODO this service reacts to all success from the previous task. Is this correct?
+        await updateTaskStatus(taskUri, env.TASK_ONGOING_STATUS);
+
+        const submission = await createSubmissionFromSubmissionTask(taskUri);
+        await processSubmission(submission);
+
+        await updateTaskStatus(taskUri, env.TASK_SUCCESS_STATUS);
+      } catch (error) {
+        const message = `Something went wrong while generating form data for task ${taskUri}`;
+        console.error(`${message}\n`, error.message);
+        console.error(error);
+        const errorUri = await saveError({ message, detail: error.message });
+        await updateTaskStatus(taskUri, env.TASK_FAILURE_STATUS, errorUri);
+      }
+    }
+
+    //Deletions will never get here. The delta-notifier was set up to only forward SENT and CONCEPT submission.
+    //Is this a relic from the past?
+    //const deletions = await processDeletions(delta);
+  } catch (error) {
+    const message =
+      'The task for enriching a submission could not even be started or finished due to an unexpected problem.';
+    console.error(`${message}\n`, error.message);
+    console.error(error);
+    await saveError({ message, detail: error.message });
   }
 });
 
@@ -58,57 +86,59 @@ app.put('/submission-documents/:uuid/flatten', async function (req, res) {
   }
 });
 
-async function processInsertions(delta) {
-  // TODO make it more easy to add new triggers <=> creation strategies.
-  let submissions = [];
+//async function processInsertions(delta) {
+//  // TODO make it more easy to add new triggers <=> creation strategies.
+//  let submissions = [];
+//
+//  // get submissions for submission URIs
+//  let inserts = delta.getInsertsFor(triple(undefined, ADMS('status'), new NamedNode(SUBMISSION_SENT_STATUS)));
+//  for (let triple of inserts) {
+//    const submission = await createSubmissionFromSubmission(triple.subject.value);
+//    if (submission)
+//      submissions.push(submission);
+//  }
+//
+//  // get submissions for submission-task URIs
+//  inserts = delta.getInsertsFor(triple(undefined, ADMS('status'), new NamedNode(SUBMISSION_TASK_SUCCESSFUL)));
+//  for (let triple of inserts) {
+//    const submission = await createSubmissionFromSubmissionTask(triple.subject.value);
+//    if (submission)
+//      submissions.push(submission);
+//  }
+//
+//  if (submissions.length) {
+//    processSubmissions(submissions); // don't await async processing
+//  }
+//  return submissions;
+//}
 
-  // get submissions for submission URIs
-  let inserts = delta.getInsertsFor(triple(undefined, ADMS('status'), new NamedNode(SUBMISSION_SENT_STATUS)));
-  for (let triple of inserts) {
-    const submission = await createSubmissionFromSubmission(triple.subject.value);
-    if (submission) submissions.push(submission);
-  }
-
-  // get submissions for submission-task URIs
-  inserts = delta.getInsertsFor(triple(undefined, ADMS('status'), new NamedNode(SUBMISSION_TASK_SUCCESSFUL)));
-  for (const triple of inserts) {
-    const submission = await createSubmissionFromSubmissionTask(triple.subject.value);
-    if (submission) submissions.push(submission);
-  }
-
-  if (submissions.length) {
-    processSubmissions(submissions); // don't await async processing
-  }
-  return submissions;
-}
-
-async function processSubmissions(submissions) {
-  for (const submission of submissions) {
-    try {
-      await processSubmission(submission);
-    } catch (e) {
-      console.log('Something went wrong while trying to extract the form-data from the submissions');
-      console.log(`Exception: ${e.stack}`);
-    }
-  }
-}
+//async function processSubmissions(submissions) {
+//  for (const submission of submissions) {
+//    try {
+//      await processSubmission(submission);
+//    } catch (e) {
+//      console.log('Something went wrong while trying to extract the form-data from the submissions');
+//      console.log(`Exception: ${e.stack}`);
+//    }
+//  }
+//}
 
 async function processSubmission(submission) {
   const form = new FormData({ submission });
   await form.flatten();
 }
 
-async function processDeletions(delta) {
-  const deletions = delta.getInsertsFor(triple(undefined, ADMS('status'), new NamedNode(SUBMISSION_DELETED_STATUS)));
-
-  for (const triple of deletions) {
-    try {
-      await deleteFormDataFromSubmission(triple.subject.value);
-    } catch (e) {
-      console.log('Something went wrong while trying to delete the form data');
-      console.log(`Exception: ${e.stack}`);
-    }
-  }
-
-  return deletions;
-}
+//async function processDeletions(delta) {
+//  let deletions = delta.getInsertsFor(triple(undefined, ADMS('status'), new NamedNode(SUBMISSION_DELETED_STATUS)));
+//
+//  for (let triple of deletions) {
+//    try {
+//      await deleteFormDataFromSubmission(triple.subject.value);
+//    } catch (e) {
+//      console.log('Something went wrong while trying to delete the form data');
+//      console.log(`Exception: ${e.stack}`);
+//    }
+//  }
+//
+//  return deletions;
+//}

--- a/env.js
+++ b/env.js
@@ -1,0 +1,53 @@
+export const CREATOR =
+  'http://lblod.data.gift/services/toezicht-flattened-form-data-generator';
+
+export const TASK_ONGOING_STATUS =
+  'http://redpencil.data.gift/id/concept/JobStatus/busy';
+export const TASK_SUCCESS_STATUS =
+  'http://redpencil.data.gift/id/concept/JobStatus/success';
+export const TASK_FAILURE_STATUS =
+  'http://redpencil.data.gift/id/concept/JobStatus/failed';
+
+export const FORM_DATA_GENERATE_OPERATION =
+  'http://lblod.data.gift/id/jobs/concept/TaskOperation/form-data-generate';
+
+const PREFIX_TABLE = {
+  meb: 'http://rdf.myexperiment.org/ontologies/base/',
+  xsd: 'http://www.w3.org/2001/XMLSchema#',
+  pav: 'http://purl.org/pav/',
+  dct: 'http://purl.org/dc/terms/',
+  melding: 'http://lblod.data.gift/vocabularies/automatische-melding/',
+  lblodBesluit: 'http://lblod.data.gift/vocabularies/besluit/',
+  adms: 'http://www.w3.org/ns/adms#',
+  muAccount: 'http://mu.semte.ch/vocabularies/account/',
+  eli: 'http://data.europa.eu/eli/ontology#',
+  org: 'http://www.w3.org/ns/org#',
+  elod: 'http://linkedeconomy.org/ontology#',
+  nie: 'http://www.semanticdesktop.org/ontologies/2007/01/19/nie#',
+  prov: 'http://www.w3.org/ns/prov#',
+  mu: 'http://mu.semte.ch/vocabularies/core/',
+  foaf: 'http://xmlns.com/foaf/0.1/',
+  nfo: 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#',
+  ext: 'http://mu.semte.ch/vocabularies/ext/',
+  http: 'http://www.w3.org/2011/http#',
+  rpioHttp: 'http://redpencil.data.gift/vocabularies/http/',
+  dgftSec: 'http://lblod.data.gift/vocabularies/security/',
+  dgftOauth: 'http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/',
+  wotSec: 'https://www.w3.org/2019/wot/security#',
+  task: 'http://redpencil.data.gift/vocabularies/tasks/',
+  asj: 'http://data.lblod.info/id/automatic-submission-job/',
+};
+
+export const PREFIXES = (() => {
+  const all = [];
+  for (const key in PREFIX_TABLE)
+    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
+  return all.join('\n');
+})();
+
+export function getPrefixes(collOfPrefixes) {
+  const all = [];
+  for (const key of collOfPrefixes)
+    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
+  return all.join('\n');
+}

--- a/env.js
+++ b/env.js
@@ -44,10 +44,3 @@ export const PREFIXES = (() => {
     all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
   return all.join('\n');
 })();
-
-export function getPrefixes(collOfPrefixes) {
-  const all = [];
-  for (const key of collOfPrefixes)
-    all.push(`PREFIX ${key}: <${PREFIX_TABLE[key]}>`);
-  return all.join('\n');
-}

--- a/lib/delta.js
+++ b/lib/delta.js
@@ -1,5 +1,4 @@
 import { NamedNode, triple } from 'rdflib';
-import flatten from 'lodash.flatten';
 
 export class Delta {
   constructor(delta) {
@@ -7,18 +6,27 @@ export class Delta {
   }
 
   get inserts() {
-    return flatten(this.delta.map((changeSet) => changeSet.inserts));
+    return this.delta.map((changeSet) => changeSet.inserts).flat();
   }
 
   getInsertsFor(trigger) {
-    return this.inserts.filter((triple) => this.isTriggerTriple(triple, trigger)).map(this.mapToRdfTriple);
+    return this.inserts
+      .filter((triple) => this.isTriggerTriple(triple, trigger))
+      .map(this.mapToRdfTriple);
   }
 
   isTriggerTriple(triple, trigger) {
-    return triple.predicate.value === trigger.predicate.value && triple.object.value === trigger.object.value;
+    return (
+      triple.predicate.value === trigger.predicate.value &&
+      triple.object.value === trigger.object.value
+    );
   }
 
   mapToRdfTriple(t) {
-    return triple(new NamedNode(t.subject.value), new NamedNode(t.predicate.value), new NamedNode(t.object.value));
+    return triple(
+      new NamedNode(t.subject.value),
+      new NamedNode(t.predicate.value),
+      new NamedNode(t.object.value)
+    );
   }
 }

--- a/lib/submission-error.js
+++ b/lib/submission-error.js
@@ -1,0 +1,37 @@
+import * as mas from '@lblod/mu-auth-sudo';
+import * as mu from 'mu';
+import * as env from '../env.js';
+
+export async function saveError({ message, detail, reference }) {
+  if (!message) throw 'Error needs a message describing what went wrong.';
+  const id = mu.uuid();
+  const uri = `http://data.lblod.info/errors/${id}`;
+  const q = `
+    PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
+    PREFIX oslc: <http://open-services.net/ns/core#>
+    PREFIX dct:  <http://purl.org/dc/terms/>
+    PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+    INSERT DATA {
+      GRAPH <http://mu.semte.ch/graphs/error> {
+        ${mu.sparqlEscapeUri(uri)}
+          a oslc:Error ;
+          mu:uuid ${mu.sparqlEscapeString(id)} ;
+          dct:subject ${mu.sparqlEscapeString('Automatic Submission Service')} ;
+          oslc:message ${mu.sparqlEscapeString(message)} ;
+          dct:created ${mu.sparqlEscapeDateTime(new Date().toISOString())} ;
+          ${reference ? `dct:references ${mu.sparqlEscapeUri(reference)} ;` : ''}
+          ${detail ? `oslc:largePreview ${mu.sparqlEscapeString(detail)} ;` : ''}
+          dct:creator ${mu.sparqlEscapeUri(env.CREATOR)} .
+      }
+    }
+   `;
+  try {
+    await mas.updateSudo(q);
+    return uri;
+  } catch (e) {
+    console.warn(
+      `[WARN] Something went wrong while trying to store an error.\nMessage: ${e}\nQuery: ${q}`
+    );
+  }
+}

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -15,7 +15,7 @@ export async function updateTaskStatus(taskUri, status, errorUri) {
   const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
 
   const statusUpdateQuery = `
-    ${env.getPrefixes(['xsd', 'adms', 'dct', 'task', 'asj', 'nfo', 'mu', 'ext'])}
+    ${env.PREFIXES}
     DELETE {
       GRAPH ?g {
         ${taskUriSparql}

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -1,0 +1,46 @@
+import * as mu from 'mu';
+import * as mas from '@lblod/mu-auth-sudo';
+import * as env from '../env.js';
+
+/**
+ * Updates the state of the given task to the specified status with potential error message or resultcontainer file
+ *
+ * @param string taskUri URI of the task
+ * @param string status URI of the new status
+ * @param string or undefined URI of the error that needs to be attached
+ */
+export async function updateTaskStatus(taskUri, status, errorUri) {
+  const taskUriSparql = mu.sparqlEscapeUri(taskUri);
+  const nowSparql = mu.sparqlEscapeDateTime(new Date().toISOString());
+  const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
+
+  const statusUpdateQuery = `
+    ${env.getPrefixes(['xsd', 'adms', 'dct', 'task', 'asj', 'nfo', 'mu', 'ext'])}
+    DELETE {
+      GRAPH ?g {
+        ${taskUriSparql}
+          adms:status ?oldStatus ;
+          dct:modified ?oldModified .
+      }
+    }
+    INSERT {
+      GRAPH ?g {
+        ${taskUriSparql}
+          adms:status ${mu.sparqlEscapeUri(status)} ;
+          ${hasError ? `task:error ${mu.sparqlEscapeUri(errorUri)} ;` : ''}
+          ${(status === env.TASK_SUCCESS_STATUS) ? `task:resultsContainer ?inputContainer ;` : ''}
+          dct:modified ${nowSparql} .
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        ${taskUriSparql}
+          adms:status ?oldStatus ;
+          ${(status === env.TASK_SUCCESS_STATUS) ? `task:inputContainer ?inputContainer ;` : ''}
+          dct:modified ?oldModified .
+      }
+    }
+  `;
+  await mas.updateSudo(statusUpdateQuery);
+}
+

--- a/lib/submission.js
+++ b/lib/submission.js
@@ -42,16 +42,15 @@ async function createSubmission(q) {
       const binding = result.results.bindings[0];
       return new Submission({
         uri: binding['submission'].value,
-        resourceURI: binding['submittedResourceURI'].value,
-        ttl: await new TurtleFile({ uri: binding['ttlFileURI'].value }).read(),
+        resourceURI: binding['submittedDocument'].value,
+        ttl: await new TurtleFile({ uri: binding['physicalFile'].value }).read(),
       });
     } else {
       console.log('No submission found.');
-      return null;
     }
   } catch (e) {
     console.log('Something went wrong while trying to retrieve/create the submissions.');
     console.log(`Exception: ${e.stack}`);
-    return null;
+    throw e;
   }
 }

--- a/lib/submission.js
+++ b/lib/submission.js
@@ -9,7 +9,6 @@ import {
 
 export const SUBMISSION_SENT_STATUS = 'http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c';
 export const SUBMISSION_DELETED_STATUS = 'http://lblod.data.gift/concepts/faa5110a-fdb2-47fa-a0d2-118e5542ef05';
-export const SUBMISSION_TASK_SUCCESSFUL = 'http://lblod.data.gift/automatische-melding-statuses/successful-concept';
 
 export class Submission {
   constructor({ uri, resourceURI, ttl }) {

--- a/util/namespaces.js
+++ b/util/namespaces.js
@@ -13,3 +13,4 @@ export const MELDING = Namespace('http://lblod.data.gift/vocabularies/automatisc
 export const PROV = Namespace('http://www.w3.org/ns/prov#');
 export const ADMS = Namespace('http://www.w3.org/ns/adms#');
 export const XSD = Namespace('http://www.w3.org/2001/XMLSchema#');
+export const TASK = Namespace('http://redpencil.data.gift/vocabularies/tasks/')

--- a/util/queries.js
+++ b/util/queries.js
@@ -36,14 +36,14 @@ export function createSubmissionFromAutoSubmissionTaskQuery(uri) {
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX adms: <http://www.w3.org/ns/adms#>
-PREFIX melding: <http://lblod.data.gift/vocabularies/automatische-melding/>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
 
 SELECT ?submission ?ttlFileURI ?submittedResourceURI
 WHERE {
   ${sparqlEscapeUri(uri)}
-    a melding:AutomaticSubmissionTask ;
-    prov:generated ?submission ;
-    adms:status <http://lblod.data.gift/automatische-melding-statuses/successful-concept> .
+    a task:Task ;
+    dct:isPartOf ?job .
+  ?job prov:generated ?submission .
   ?submission dct:subject ?submittedResourceURI .
   ?submittedResourceURI dct:source ?ttlFileURI .
   ?ttlFileURI dct:type <http://data.lblod.gift/concepts/form-data-file-type> .

--- a/util/queries.js
+++ b/util/queries.js
@@ -6,47 +6,53 @@ import { MELDING, PROV } from './namespaces';
 export function createSubmissionForQuery(uri) {
   return `
 PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-SELECT ?submission ?ttlFileURI ?submittedResourceURI
+SELECT ?submission ?logicalFile ?physicalFile ?submittedDocument
 WHERE {
   BIND (${sparqlEscapeUri(uri)} as ?submission)
-  ?submission dct:subject ?submittedResourceURI .
-  ?submittedResourceURI dct:source ?ttlFileURI .
-  ?ttlFileURI dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
+  ?submission dct:subject ?submittedDocument .
+  ?submittedDocument dct:source ?logicalFile .
+  ?logicalFile dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
+  ?physicalFile nie:dataSource ?logicalFile .
 } LIMIT 1`;
 }
 
 export function createSubmissionFromSubmittedResourceQuery(uuid) {
   return `
 PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX mu:  <http://mu.semte.ch/vocabularies/core/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-SELECT ?submission ?ttlFileURI ?submittedResourceURI
+SELECT ?submission ?logicalFile ?physicalFile ?submittedDocument
 WHERE {
-  ?submittedResourceURI mu:uuid ${sparqlEscapeString(uuid)} .
-  ?submission dct:subject ?submittedResourceURI .
-  ?submittedResourceURI dct:source ?ttlFileURI .
-  ?ttlFileURI dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
+  ?submittedDocument mu:uuid ${sparqlEscapeString(uuid)} .
+  ?submission dct:subject ?submittedDocument .
+  ?submittedDocument dct:source ?logicalFile .
+  ?logicalFile dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
+  ?physicalFile nie:dataSource ?logicalFile .
 } LIMIT 1`;
 }
 
 // TODO ask about the dct:type of file.
 export function createSubmissionFromAutoSubmissionTaskQuery(uri) {
   return `
-PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX dct:  <http://purl.org/dc/terms/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX adms: <http://www.w3.org/ns/adms#>
 PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX nie:  <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 
-SELECT ?submission ?ttlFileURI ?submittedResourceURI
+SELECT ?submission ?logicalFile ?physicalFile ?submittedDocument
 WHERE {
   ${sparqlEscapeUri(uri)}
     a task:Task ;
     dct:isPartOf ?job .
   ?job prov:generated ?submission .
-  ?submission dct:subject ?submittedResourceURI .
-  ?submittedResourceURI dct:source ?ttlFileURI .
-  ?ttlFileURI dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
+  ?submission dct:subject ?submittedDocument .
+  ?submittedDocument dct:source ?logicalFile .
+  ?logicalFile dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
+  ?physicalFile nie:dataSource ?logicalFile .
 } LIMIT 1`;
 }
 


### PR DESCRIPTION
This PR makes this service integrate with the job-controller-service. It listens for scheduled tasks with operation "form-data-generate" to start the process for the given submission. It also listens to submissions with a "sent" status to start its process.

Most of this service has been left alone, except for the parts where tasks were managed.

**NOTE**: I made another PR with linting fixes. This PR is based on that.