### PR TITLE
Feature/attach status to form

### DIFF
--- a/lib/form-data.js
+++ b/lib/form-data.js
@@ -1,7 +1,7 @@
 import {uuid} from 'mu';
 import extractProperties from './extractor';
 import {querySudo as query, updateSudo as update} from '@lblod/mu-auth-sudo';
-import {completeFormDataFromSubmissionQuery, insertFormDataQuery, deleteFormDataQuery} from '../util/queries';
+import {completeFormDataFromSubmissionQuery, insertFormDataQuery, deleteFormDataQuery, askSubmissionSendStatus} from '../util/queries';
 
 export class FormData {
     constructor({submission}) {
@@ -33,13 +33,18 @@ export class FormData {
             await update(q);
         }
 
+        const submissionIsStatusSend = await query(askSubmissionSendStatus(this.submission.uri));
+        this.submission.isStatusSend = submissionIsStatusSend.boolean;
+
+
         // insert flattened resource in triplestore
         const q = insertFormDataQuery({
             uri: this.uri,
             uuid: this.uuid,
             submission: this.submission,
-            properties: this.properties
+            properties: this.properties,
         });
+      
         await update(q);
     }
 }


### PR DESCRIPTION
Now whenever formData gets flattened, it will check the status of the parent submission. If the submission has status SEND, it will also attach that status to the formData object itself.

Note: preferably we would want to mirror the status triple of the submission object on the formData object. within the changes made in this PR, the focus lies on the SEND status. Unless, the parent submission has the SEND status, nothing really happens.