### PR TITLE
Reverting to previous file linking

### DIFF
--- a/util/queries.js
+++ b/util/queries.js
@@ -14,9 +14,9 @@ SELECT ?submission ?logicalFile ?physicalFile ?submittedDocument
 WHERE {
   BIND (${sparqlEscapeUri(uri)} as ?submission)
   ?submission dct:subject ?submittedDocument .
-  ?submittedDocument dct:source ?logicalFile .
-  ?logicalFile dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
+  ?submittedDocument dct:source ?physicalFile .
   ?physicalFile nie:dataSource ?logicalFile .
+  ?logicalFile dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
 } LIMIT 1`;
 }
 
@@ -30,9 +30,9 @@ SELECT ?submission ?logicalFile ?physicalFile ?submittedDocument
 WHERE {
   ?submittedDocument mu:uuid ${sparqlEscapeString(uuid)} .
   ?submission dct:subject ?submittedDocument .
-  ?submittedDocument dct:source ?logicalFile .
-  ?logicalFile dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
+  ?submittedDocument dct:source ?physicalFile .
   ?physicalFile nie:dataSource ?logicalFile .
+  ?logicalFile dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
 } LIMIT 1`;
 }
 
@@ -52,9 +52,9 @@ WHERE {
     dct:isPartOf ?job .
   ?job prov:generated ?submission .
   ?submission dct:subject ?submittedDocument .
-  ?submittedDocument dct:source ?logicalFile .
-  ?logicalFile dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
+  ?submittedDocument dct:source ?physicalFile .
   ?physicalFile nie:dataSource ?logicalFile .
+  ?logicalFile dct:type <http://data.lblod.gift/concepts/form-data-file-type> .
 } LIMIT 1`;
 }
 


### PR DESCRIPTION
In a previous version, the imported file was linked to the Submitted Document by means of a physical file. Due to the introduction of the cogs:Job model and the interoperability with the job-controller and the dashboard, the Submitted Document was linked to a logical file, just like the task for this service.

We are now rolling back that decision because of backwards compatibility problems, but while keeping the interoperability with the dashboard and the job-controller.