### PR TITLE
Only insert in one graph

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+import * as env from 'env-var';
+
+export const GRAPH_TEMPLATE = env.get('GRAPH_TEMPLATE')
+  .example('http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker')
+  .default('http://mu.semte.ch/graphs/organizations/~ORGANIZATION_ID~/LoketLB-toezichtGebruiker')
+  .asUrlString();
+
+(function checkEnvVars() {
+  if (!/~ORGANIZATION_ID~/g.test(GRAPH_TEMPLATE))
+    throw new Error(`The GRAPH_TEMPLATE environment variable ${GRAPH_TEMPLATE} does not contain a ~ORGANIZATION_ID~.`);
+})();

--- a/lib/form-data.js
+++ b/lib/form-data.js
@@ -15,7 +15,7 @@ export class FormData {
   }
 
   async flatten() {
-    const result = await query(completeFormDataFromSubmissionQuery(this.submission.uri));
+    const result = await query(completeFormDataFromSubmissionQuery(this.submission));
     const isNew = result.results.bindings.length == 0;
     if (isNew) {
       console.log(`No form data found for submission <${this.submission.uri}>. Going to create a  new flattened form data resource.`);
@@ -34,7 +34,7 @@ export class FormData {
     });
 
     if (!isNew) {
-      const q = deleteFormDataQuery(this.uri);
+      const q = deleteFormDataQuery(this.uri, this.submission.graph);
       await update(q);
     }
 

--- a/lib/submission-task.js
+++ b/lib/submission-task.js
@@ -9,7 +9,7 @@ import * as env from '../env.js';
  * @param string status URI of the new status
  * @param string or undefined URI of the error that needs to be attached
  */
-export async function updateTaskStatus(taskUri, status, errorUri) {
+export async function updateTaskStatus(taskUri, status, errorUri, graph) {
   const taskUriSparql = mu.sparqlEscapeUri(taskUri);
   const nowSparql = mu.sparqlEscapeDateTime(new Date().toISOString());
   const hasError = errorUri && status === env.TASK_FAILURE_STATUS;
@@ -17,14 +17,14 @@ export async function updateTaskStatus(taskUri, status, errorUri) {
   const statusUpdateQuery = `
     ${env.PREFIXES}
     DELETE {
-      GRAPH ?g {
+      GRAPH ${mu.sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ?oldStatus ;
           dct:modified ?oldModified .
       }
     }
     INSERT {
-      GRAPH ?g {
+      GRAPH ${mu.sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ${mu.sparqlEscapeUri(status)} ;
           ${hasError ? `task:error ${mu.sparqlEscapeUri(errorUri)} ;` : ''}
@@ -33,7 +33,7 @@ export async function updateTaskStatus(taskUri, status, errorUri) {
       }
     }
     WHERE {
-      GRAPH ?g {
+      GRAPH ${mu.sparqlEscapeUri(graph)} {
         ${taskUriSparql}
           adms:status ?oldStatus ;
           ${(status === env.TASK_SUCCESS_STATUS) ? `task:inputContainer ?inputContainer ;` : ''}
@@ -44,3 +44,16 @@ export async function updateTaskStatus(taskUri, status, errorUri) {
   await mas.updateSudo(statusUpdateQuery);
 }
 
+export async function getOrganisationIdFromTask(taskUri) {
+  const response = await mas.querySudo(`
+    ${env.PREFIXES}
+    SELECT DISTINCT ?organisationId WHERE {
+      ${mu.sparqlEscapeUri(taskUri)} dct:isPartOf ?job .
+      ?job prov:generated ?submission .
+      ?submission pav:createdBy ?bestuurseenheid .
+      ?bestuurseenheid mu:uuid ?organisationId .
+    }
+    LIMIT 1
+  `);
+  return response?.results?.bindings[0]?.organisationId?.value;
+}

--- a/lib/submission.js
+++ b/lib/submission.js
@@ -6,15 +6,17 @@ import {
   createSubmissionFromSubmittedResourceQuery,
   deleteFormDataFromSubmissionQuery,
 } from '../util/queries';
+import * as config from '../config';
 
 export const SUBMISSION_SENT_STATUS = 'http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c';
 export const SUBMISSION_DELETED_STATUS = 'http://lblod.data.gift/concepts/faa5110a-fdb2-47fa-a0d2-118e5542ef05';
 
 export class Submission {
-  constructor({ uri, resourceURI, ttl }) {
+  constructor({ uri, resourceURI, ttl, graph }) {
     this.uri = uri;
     this.resourceURI = resourceURI;
     this.ttl = ttl;
+    this.graph = graph;
   }
 }
 
@@ -30,8 +32,8 @@ export async function createSubmissionFromSubmissionTask(uri) {
   return await createSubmission(createSubmissionFromAutoSubmissionTaskQuery(uri));
 }
 
-export async function deleteFormDataFromSubmission(uri) {
-  await query(deleteFormDataFromSubmissionQuery(uri));
+export async function deleteFormDataFromSubmission(uri, graph) {
+  await query(deleteFormDataFromSubmissionQuery(uri, graph));
 }
 
 async function createSubmission(q) {
@@ -44,6 +46,7 @@ async function createSubmission(q) {
         uri: binding['submission'].value,
         resourceURI: binding['submittedDocument'].value,
         ttl: await new TurtleFile({ uri: binding['physicalFile'].value }).read(),
+        graph: config.GRAPH_TEMPLATE.replace('~ORGANIZATION_ID~', binding.organisationId.value),
       });
     } else {
       console.log('No submission found.');

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   "license": "MIT",
   "dependencies": {
     "@lblod/mu-auth-sudo": "0.2.0",
-    "lodash.flatten": "4.4.0",
+    "body-parser": "1.19.0",
+    "env-var": "^7.3.0",
     "fs-extra": "8.1.0",
-    "rdflib": "1.0.6",
-    "body-parser": "1.19.0"
+    "lodash.flatten": "4.4.0",
+    "rdflib": "1.0.6"
   },
   "devDependencies": {
     "eslint": "^8.19.0",


### PR DESCRIPTION
In order to improve data security, the services in the automatic submission flow should only insert data in one specific controlled graph.

This fixes issues related to data spreading in graphs that should not contain that data. More specific for the vendor-data-distribution-service.

This PR includes a configuration file where the graph template is loaded from environment variables, but with sensible defaults so that nothing special should be done in most cases. The code is adapted to always compute the graph from the template in combination with the organisation ID before inserting into the triplestore.