### PR TITLE
Feature/extract article data

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Currently, this service will also extract `besluit:Artikel` information provided
 ```
 It's important to consider how we want to evolve this service. The point is that more and more information included in the `besluit:Besluit` is information we want to act upon.
 Note: We extract only white-listed predicates, to be safe. This mainly to cover the 'cross-referencing' use case.
+Note 2: probably once we migrate to forms-v2 a lot of these intermediate steps are going to be simplified a lot.
 
 ## Related services
 The following services are also involved in the automatic processing of a submission:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Currently, this service will also extract `besluit:Artikel` information provided
 
 ```
 It's important to consider how we want to evolve this service. The point is that more and more information included in the `besluit:Besluit` is information we want to act upon.
+Note: We extract only white-listed predicates, to be safe. This mainly to cover the 'cross-referencing' use case.
 
 ## Related services
 The following services are also involved in the automatic processing of a submission:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ A `melding:FormData` resource is generated based on the data found in the TTL fi
 | ext:regulationType                | rdf:type (that is part of the regulation-type concept-scheme)     |
 | ext:taxType                       | rdf:type (that is part of the tax-type concept-scheme)            |
 
+### Extra mappings
+This service has been extended to do more than the name would suggest. It now extracts information from the form-data.ttl file and 'flattens' it, mapping the extracted information onto one resource. Perhaps, we should reconsider the name of this service from "toezicht-flattend-form-data-generator" to something more general, such as "toezicht-form-data-extractor".
+
+Currently, this service will also extract `besluit:Artikel` information provided in the `form-data.ttl` and attach it to `besluit:Besluit` in the dataset. This should look like the following:
+
+```turtle
+<http://submission> a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+  dcterms:subject <http://besluit>.
+
+<http://besluit> <http://data.europa.eu/eli/ontology#has_part> <http://artikel>.
+<http://artikel> a besluit:Artikel.
+
+```
+It's important to consider how we want to evolve this service. The point is that more and more information included in the `besluit:Besluit` is information we want to act upon.
+
 ## Related services
 The following services are also involved in the automatic processing of a submission:
 * [automatic-submission-service](https://github.com/lblod/automatic-submission-service)

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ A `melding:FormData` resource is generated based on the data found in the TTL fi
 | ext:taxType                       | rdf:type (that is part of the tax-type concept-scheme)            |
 
 ### Extra mappings
-This service has been extended to do more than the name would suggest. It now extracts information from the form-data.ttl file and 'flattens' it, mapping the extracted information onto one resource. Perhaps, we should reconsider the name of this service from "toezicht-flattend-form-data-generator" to something more general, such as "toezicht-form-data-extractor".
-
-Currently, this service will also extract `besluit:Artikel` information provided in the `form-data.ttl` and attach it to `besluit:Besluit` in the dataset. This should look like the following:
+Previoulsy this service extracted information from the `form-data.ttl` file and 'flattened' it, mapping the extracted information onto one resource.
+Now, this service has been extended to do more than the name would suggest.
+It will also extract `besluit:Artikel` information provided in the `form-data.ttl` and attach it to `besluit:Besluit` in the dataset.
+This newly extracted data should look like the following:
 
 ```turtle
 <http://submission> a <http://rdf.myexperiment.org/ontologies/base/Submission>;
@@ -81,6 +82,7 @@ Currently, this service will also extract `besluit:Artikel` information provided
 <http://artikel> a besluit:Artikel.
 
 ```
+Perhaps, we should reconsider the name of this service from "toezicht-flattend-form-data-generator" to something more general, such as "toezicht-form-data-extractor".
 It's important to consider how we want to evolve this service. The point is that more and more information included in the `besluit:Besluit` is information we want to act upon.
 Note: We extract only white-listed predicates, to be safe. This mainly to cover the 'cross-referencing' use case.
 Note 2: probably once we migrate to forms-v2 a lot of these intermediate steps are going to be simplified a lot.

--- a/lib/form-data.js
+++ b/lib/form-data.js
@@ -70,38 +70,6 @@ export class FormData {
  * 4. Note 3: It overrules previously stored information of eli:is_about, if a cross-referended document is found.
  */
 async function manageArticle({ formDataUri, submission }) {
-  //Always flush the previsouly stored besluit:Artikel information.
-  const flushArticleQuery = `
-    PREFIX dcterms: <http://purl.org/dc/terms/>
-    PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
-    PREFIX prov: <http://www.w3.org/ns/prov#>
-    PREFIX eli: <http://data.europa.eu/eli/ontology#>
-    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-
-    DELETE {
-      GRAPH ${sparqlEscapeUri(submission.graph)} {
-        ?decision <http://data.europa.eu/eli/ontology#has_part> ?article.
-        ?article ?articleP ?articleO.
-      }
-    }
-    WHERE {
-      VALUES ?submission {
-        ${sparqlEscapeUri(submission.uri)}
-      }
-
-      ?submission
-        a meb:Submission ;
-        dcterms:subject ?decision.
-
-      ?decision <http://data.europa.eu/eli/ontology#has_part> ?article.
-
-      OPTIONAL {
-        ?article a <http://data.vlaanderen.be/ns/besluit#Artikel>;
-          ?articleP ?articleO.
-      }
-    }`;
-
-  await update(flushArticleQuery);
 
   // Extract the actual besluit:Artikel information from the form-data.ttl
   let triples = [];
@@ -157,9 +125,42 @@ async function manageArticle({ formDataUri, submission }) {
     }
   }
 
-  // Store in database
   const articleTriples = triples.map(t => t.toNT());
-  let updateQuery = `
+
+  // --------- START: Defining the queries  ---------
+
+  // Always flush the previously stored besluit:Artikel information.
+  const flushArticleQuery = `
+    PREFIX dcterms: <http://purl.org/dc/terms/>
+    PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+    PREFIX prov: <http://www.w3.org/ns/prov#>
+    PREFIX eli: <http://data.europa.eu/eli/ontology#>
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+    DELETE {
+      GRAPH ${sparqlEscapeUri(submission.graph)} {
+        ?decision <http://data.europa.eu/eli/ontology#has_part> ?article.
+        ?article ?articleP ?articleO.
+      }
+    }
+    WHERE {
+      VALUES ?submission {
+        ${sparqlEscapeUri(submission.uri)}
+      }
+
+      ?submission
+        a meb:Submission ;
+        dcterms:subject ?decision.
+
+      ?decision <http://data.europa.eu/eli/ontology#has_part> ?article.
+
+      OPTIONAL {
+        ?article a <http://data.vlaanderen.be/ns/besluit#Artikel>;
+          ?articleP ?articleO.
+      }
+    }`;
+
+  const updateArticleQuery = `
     INSERT DATA {
       GRAPH ${sparqlEscapeUri(submission.graph)} {
          ${articleTriples.join('\n')}
@@ -167,20 +168,14 @@ async function manageArticle({ formDataUri, submission }) {
     }`;
 
   /*
-   * This code handles the query logic for updating the `eli:is_about` predicate
-   * when cross-referenced documents are found in the form data.
-   *
-   * Detailed Explanation:
+   * Detailed Explanation of updateIsAboutQuery
    * 1. If cross-referenced documents are present in the form data,
    *    the `eli:is_about` predicate is updated to refer to the
    *    `bestuurseenheid` that initially created the cross-referenced document.
    * 2. WARNING: This logic flushes `eli:is_about` previously stored.
    *   In the (unlikely) case `eli:is_about` is managed by another form field AND the cross-referenced doc, we will re-think the process.
    */
-  if(crossReferencedDocuments.length) {
-    updateQuery += `
-      ;
-
+  const updateIsAboutQuery = `
       DELETE {
         GRAPH ${sparqlEscapeUri(submission.graph)} {
           ?formData <http://data.europa.eu/eli/ontology#is_about> ?eenheid.
@@ -210,9 +205,17 @@ async function manageArticle({ formDataUri, submission }) {
           ?formData <http://data.europa.eu/eli/ontology#is_about> ?eenheid.
         }
       }`;
-  }
+  // --------- END: Defining the queries  ---------
+
+  let fullQuery = flushArticleQuery;
 
   if(articleTriples.length) {
-    await update(updateQuery);
+    fullQuery += '\n ; \n' + updateArticleQuery;
   }
+
+  if(crossReferencedDocuments.length) {
+    fullQuery += '\n ; \n' + updateIsAboutQuery;
+  }
+
+  await update(fullQuery);
 }

--- a/lib/form-data.js
+++ b/lib/form-data.js
@@ -57,12 +57,11 @@ export class FormData {
 }
 
 /*
- * This function keeps the stored besluit:Artikel from the form-data.ttl 
- * in sync with what needs to be availible in the database.
+ * Keeps the stored besluit:Artikel from the form-data.ttl in sync with what needs to be available in the database.
  * Note: It's indeed a bit of a stretch to include the function in this service.
- *   I don't consider this as unlogical place to have it here, and I do think the scope, as decribed in the name of the service
- *   is way too narrow for the purpose of the service itself, i.e. extracting data from the form-data.ttl file and store it in the database
- *  So what is to reconsider here, is rather the name (and thus scope of the service) rather than (the location) of this function.
+ * I don't consider this an illogical place to have it here, and I do think the scope, as described in the name of the service,
+ * is too narrow for the purpose of the service itself, i.e. extracting data from the form-data.ttl file and storing it in the database.
+ * So what is to reconsider here is rather the name (and thus scope of the service) rather than (the location of) this function.
  */
 async function manageArticle({ submission }) {
   //Always flush the previsouly stored besluit:Artikel information.

--- a/lib/form-data.js
+++ b/lib/form-data.js
@@ -50,25 +50,33 @@ export class FormData {
         properties: this.properties,
     });
 
-    await manageArticle({ submission: this.submission });
-
     await update(q);
+
+    //Warning: It overrules previously stored information of eli:is_about, if a cross-referended document is found.
+    await manageArticle({ formDataUri: this.uri, submission: this.submission });
   }
 }
 
 /*
- * Keeps the stored besluit:Artikel from the form-data.ttl in sync with what needs to be available in the database.
- * Note: It's indeed a bit of a stretch to include the function in this service.
- * I don't consider this an illogical place to have it here, and I do think the scope, as described in the name of the service,
- * is too narrow for the purpose of the service itself, i.e. extracting data from the form-data.ttl file and storing it in the database.
- * So what is to reconsider here is rather the name (and thus scope of the service) rather than (the location of) this function.
- * Note 2: probably once we migrate to forms-v2 a lot of these intermediate steps are going to be simplified a lot.
+ * Synchronizes the stored `besluit:Artikel` from `form-data.ttl` with the database.
+ *
+ * Detailed Explanation:
+ * 1. This function ensures that the `besluit:Artikel` data in `form-data.ttl` is kept in sync with the database.
+ * 2. Note: Including this function in this service might seem a bit of a stretch.
+ *    - The current service name suggests a narrow scope focused on extracting data from `form-data.ttl` and storing it in the database.
+ *    - However, I believe it's logical to have this function here, considering its purpose.
+ *    - The real consideration should be renaming and expanding the scope of the service to reflect its broader functionality.
+ * 3. Note 2: When we migrate to `forms-v2`, many of these intermediate steps will likely be significantly simplified.
+ * 4. Note 3: It overrules previously stored information of eli:is_about, if a cross-referended document is found.
  */
-async function manageArticle({ submission }) {
+async function manageArticle({ formDataUri, submission }) {
   //Always flush the previsouly stored besluit:Artikel information.
   const flushArticleQuery = `
     PREFIX dcterms: <http://purl.org/dc/terms/>
     PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+    PREFIX prov: <http://www.w3.org/ns/prov#>
+    PREFIX eli: <http://data.europa.eu/eli/ontology#>
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
     DELETE {
       GRAPH ${sparqlEscapeUri(submission.graph)} {
@@ -77,17 +85,19 @@ async function manageArticle({ submission }) {
       }
     }
     WHERE {
-      GRAPH ${sparqlEscapeUri(submission.graph)} {
+      VALUES ?submission {
         ${sparqlEscapeUri(submission.uri)}
-          a meb:Submission ;
-          dcterms:subject ?decision.
+      }
 
-        ?decision <http://data.europa.eu/eli/ontology#has_part> ?article.
+      ?submission
+        a meb:Submission ;
+        dcterms:subject ?decision.
 
-        OPTIONAL {
-          ?article a <http://data.vlaanderen.be/ns/besluit#Artikel>;
-            ?articleP ?articleO.
-        }
+      ?decision <http://data.europa.eu/eli/ontology#has_part> ?article.
+
+      OPTIONAL {
+        ?article a <http://data.vlaanderen.be/ns/besluit#Artikel>;
+          ?articleP ?articleO.
       }
     }`;
 
@@ -102,6 +112,7 @@ async function manageArticle({ submission }) {
         )
         .map(t => t.object);
 
+  let crossReferencedDocuments = []; // We keep track of these, we need them later.
   for(const subject of potentialArticleSubjects) {
     const isArticle = submission.ttl.graph
           .match(subject,
@@ -114,12 +125,18 @@ async function manageArticle({ submission }) {
       triples = [...triples, ...isArticle];
 
       // - the cross-reference document
+      const crossReferencedTriples = submission.ttl.graph
+            .match(subject,
+                   new NamedNode("http://data.europa.eu/eli/ontology#refers_to")
+                  );
+      crossReferencedDocuments = [
+        ...crossReferencedDocuments,
+        ...crossReferencedTriples.map(t => t.object)
+      ];
+
       triples = [ ...triples,
-                  ...submission.ttl.graph
-                  .match(
-                    subject,
-                    new NamedNode("http://data.europa.eu/eli/ontology#refers_to")
-                  ) ];
+                  ...crossReferencedTriples
+                ];
 
       // - the besluit:Artikel 'type', i.e. goedering, weigering,...
       triples = [ ...triples,
@@ -142,13 +159,58 @@ async function manageArticle({ submission }) {
 
   // Store in database
   const articleTriples = triples.map(t => t.toNT());
-  const updateQuery = `
+  let updateQuery = `
     INSERT DATA {
       GRAPH ${sparqlEscapeUri(submission.graph)} {
          ${articleTriples.join('\n')}
       }
-    }
-  `;
+    }`;
+
+  /*
+   * This code handles the query logic for updating the `eli:is_about` predicate
+   * when cross-referenced documents are found in the form data.
+   *
+   * Detailed Explanation:
+   * 1. If cross-referenced documents are present in the form data,
+   *    the `eli:is_about` predicate is updated to refer to the
+   *    `bestuurseenheid` that initially created the cross-referenced document.
+   * 2. WARNING: This logic flushes `eli:is_about` previously stored.
+   *   In the (unlikely) case `eli:is_about` is managed by another form field AND the cross-referenced doc, we will re-think the process.
+   */
+  if(crossReferencedDocuments.length) {
+    updateQuery += `
+      ;
+
+      DELETE {
+        GRAPH ${sparqlEscapeUri(submission.graph)} {
+          ?formData <http://data.europa.eu/eli/ontology#is_about> ?eenheid.
+        }
+      }
+      INSERT {
+        GRAPH ${sparqlEscapeUri(submission.graph)} {
+          ?formData <http://data.europa.eu/eli/ontology#is_about> ?crossRefEenheid.
+        }
+      }
+      WHERE {
+        VALUES ?formData {
+          ${sparqlEscapeUri(formDataUri)}
+        }
+        VALUES ?crossDocument {
+          ${
+             crossReferencedDocuments
+               .map(to => to.toNT())
+               .join('\n')
+           }
+        }
+        ?submission <http://purl.org/dc/terms/subject> ?crossDocument;
+          a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+          <http://purl.org/pav/createdBy> ?crossRefEenheid.
+
+        OPTIONAL {
+          ?formData <http://data.europa.eu/eli/ontology#is_about> ?eenheid.
+        }
+      }`;
+  }
 
   if(articleTriples.length) {
     await update(updateQuery);

--- a/lib/form-data.js
+++ b/lib/form-data.js
@@ -1,4 +1,5 @@
-import { uuid } from 'mu';
+import { uuid, sparqlEscapeUri } from 'mu';
+import { NamedNode, triple } from 'rdflib';
 import extractProperties from './extractor';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
 import {
@@ -49,6 +50,88 @@ export class FormData {
         properties: this.properties,
     });
 
+    await manageArticle({ submission: this.submission });
+
     await update(q);
+  }
+}
+
+/*
+ * This function keeps the stored besluit:Artikel from the form-data.ttl 
+ * in sync with what needs to be availible in the database.
+ * Note: It's indeed a bit of a stretch to include the function in this service.
+ *   I don't consider this as unlogical place to have it here, and I do think the scope, as decribed in the name of the service
+ *   is way too narrow for the purpose of the service itself, i.e. extracting data from the form-data.ttl file and store it in the database
+ *  So what is to reconsider here, is rather the name (and thus scope of the service) rather than (the location) of this function.
+ */
+async function manageArticle({ submission }) {
+  //Always flush the previsouly stored besluit:Artikel information.
+  const flushArticleQuery = `
+    PREFIX dcterms: <http://purl.org/dc/terms/>
+    PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+
+    DELETE {
+      GRAPH ${sparqlEscapeUri(submission.graph)} {
+        ?decision <http://data.europa.eu/eli/ontology#has_part> ?article.
+        ?article ?articleP ?articleO.
+      }
+    }
+    WHERE {
+      GRAPH ${sparqlEscapeUri(submission.graph)} {
+        ${sparqlEscapeUri(submission.uri)}
+          a meb:Submission ;
+          dcterms:subject ?decision.
+
+        ?decision <http://data.europa.eu/eli/ontology#has_part> ?article.
+
+        OPTIONAL {
+          ?article a <http://data.vlaanderen.be/ns/besluit#Artikel>;
+            ?articleP ?articleO.
+        }
+      }
+    }`;
+
+  await update(flushArticleQuery);
+
+  // Extract the actual besluit:Artikel information from the form-data.ttl
+  let triples = [];
+  const potentialArticleSubjects = submission.ttl.graph
+        .match(
+          new NamedNode(submission.resourceURI),
+          new NamedNode("http://data.europa.eu/eli/ontology#has_part")
+        )
+        .map(t => t.object);
+
+  for(const subject of potentialArticleSubjects) {
+    const isArticle = submission.ttl.graph
+          .match(subject,
+               new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+               new NamedNode('http://data.vlaanderen.be/ns/besluit#Artikel'));
+    if(isArticle.length) {
+      triples = [ ...triples, ...submission.ttl.graph.match(subject) ];
+
+      //Note: links the besluit:Artikel to the dcterms:subject
+      triples = [ ...triples,
+                  ...submission.ttl.graph
+                  .match(
+                    new NamedNode(submission.resourceURI),
+                    new NamedNode("http://data.europa.eu/eli/ontology#has_part"),
+                    subject)
+                ];
+    }
+  }
+
+  // Store in database
+  const articleTriples = triples.map(t => t.toNT());
+  const updateQuery = `
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(submission.graph)} {
+         ${articleTriples.join('\n')}
+      }
+    }
+  `;
+
+  if(articleTriples.length) {
+    await update(updateQuery);
   }
 }

--- a/lib/form-data.js
+++ b/lib/form-data.js
@@ -62,6 +62,7 @@ export class FormData {
  * I don't consider this an illogical place to have it here, and I do think the scope, as described in the name of the service,
  * is too narrow for the purpose of the service itself, i.e. extracting data from the form-data.ttl file and storing it in the database.
  * So what is to reconsider here is rather the name (and thus scope of the service) rather than (the location of) this function.
+ * Note 2: probably once we migrate to forms-v2 a lot of these intermediate steps are going to be simplified a lot.
  */
 async function manageArticle({ submission }) {
   //Always flush the previsouly stored besluit:Artikel information.

--- a/lib/form-data.js
+++ b/lib/form-data.js
@@ -107,9 +107,28 @@ async function manageArticle({ submission }) {
                new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
                new NamedNode('http://data.vlaanderen.be/ns/besluit#Artikel'));
     if(isArticle.length) {
-      triples = [ ...triples, ...submission.ttl.graph.match(subject) ];
+      // We're only using a white-list of information we want to extract:
 
-      //Note: links the besluit:Artikel to the dcterms:subject
+      // - the rdf:type
+      triples = [...triples, ...isArticle];
+
+      // - the cross-reference document
+      triples = [ ...triples,
+                  ...submission.ttl.graph
+                  .match(
+                    subject,
+                    new NamedNode("http://data.europa.eu/eli/ontology#refers_to")
+                  ) ];
+
+      // - the besluit:Artikel 'type', i.e. goedering, weigering,...
+      triples = [ ...triples,
+                  ...submission.ttl.graph
+                  .match(
+                    subject,
+                    new NamedNode("http://data.europa.eu/eli/ontology#type_document")
+                  ) ];
+
+      // - links the besluit:Artikel to the dcterms:subject
       triples = [ ...triples,
                   ...submission.ttl.graph
                   .match(


### PR DESCRIPTION
This PR is related to [DL-5868]. It extracts `besluit:Artikel` information from the `form-data.ttl`. 
Besides the usual code review, I would suggest waiting on [DL-5866] before testing this, since testing this in an isolated manner is rather complicated to set up and very long to explain.

So, supposing [DL-5866] is working correctly, after saving the form in the module toezicht, you can query the database and look for something similar to

```
<http://submission> a <http://rdf.myexperiment.org/ontologies/base/Submission>;
  dcterms:subject <http://besluit>.

<http://besluit> <http://data.europa.eu/eli/ontology#has_part> <http://artikel>.
<http://artikel> a besluit:Artikel.
```
If cross-referenced documents are present in the form data, the `eli:is_about` predicate is updated to refer to the  `bestuurseenheid` that initially created the cross-referenced document. So this will result in 
```
<http://form-data/1> eli:is_about <http://eenheid/which/created/the/document/which/is/cross-referenced>
```
   


Meanwhile, I release `1.4.0-rc.2` so it can be included in https://github.com/lblod/app-digitaal-loket/pull/575